### PR TITLE
feat(base): add `pinact` pre-commit hook for GitHub Actions SHA pinning

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -10,13 +10,13 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/create-github-app-token@v3
+      - uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
         id: app-token
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0
         id: release
         with:
           token: ${{ steps.app-token.outputs.token }}
@@ -25,7 +25,7 @@ jobs:
 
       - name: Update README version in release PR
         if: steps.release.outputs.prs_created == 'true'
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ fromJSON(steps.release.outputs.pr).headBranchName }}
           token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/renovate-copier.yml
+++ b/.github/workflows/renovate-copier.yml
@@ -17,13 +17,13 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.head_ref }}
           token: ${{ steps.app-token.outputs.token }}
@@ -35,7 +35,7 @@ jobs:
           fi
 
       - name: Commit and push changes
-        uses: suzuki-shunsuke/commit-action@v0.1.1
+        uses: suzuki-shunsuke/commit-action@f12e2d628a4ab72dcefe7890ae07e8dbf1e201b9 # v0.1.1
         with:
           commit_message: 'chore: restore executable bit on scripts/bootstrap'
           workflow: deny

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,13 +14,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/create-github-app-token@v3
+      - uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
         id: app-token
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
           fetch-depth: 2
@@ -41,7 +41,7 @@ jobs:
             echo "skip_commit=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - uses: jdx/mise-action@v4
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
 
       - name: Run lefthook
         id: lefthook
@@ -58,7 +58,7 @@ jobs:
 
       - name: Commit formatted files
         if: ${{ !cancelled() && steps.check-auto-format.outputs.skip_commit != 'true' }}
-        uses: suzuki-shunsuke/commit-action@v0.1.1
+        uses: suzuki-shunsuke/commit-action@f12e2d628a4ab72dcefe7890ae07e8dbf1e201b9 # v0.1.1
         with:
           commit_message: 'style: auto-format'
           workflow: deny

--- a/.mise.toml
+++ b/.mise.toml
@@ -3,6 +3,7 @@ lefthook = "2.1.4"
 
 # lefthook hooks
 actionlint = "1.7.11"
+pinact = "3.9.0"
 node = "24.14.0"
 "github:fohte/basefmt" = "0.1.0"
 "npm:@commitlint/cli" = "20.5.0"

--- a/README.md
+++ b/README.md
@@ -53,10 +53,11 @@ Language-agnostic hooks that can be used across any project regardless of progra
 
 #### `pre-commit`
 
-| Hook         | Description                                      | Requirements                                             |
-| ------------ | ------------------------------------------------ | -------------------------------------------------------- |
-| `format`     | Remove trailing whitespace, ensure final newline | [basefmt](https://github.com/fohte/basefmt) (mise)       |
-| `prettier`   | Auto-format with Prettier                        | [Prettier](https://prettier.io/) (bun/pnpm/npm/mise)     |
-| `shellcheck` | Lint shell scripts                               | [ShellCheck](https://www.shellcheck.net/) (mise)         |
-| `shfmt`      | Format shell scripts                             | [shfmt](https://github.com/mvdan/sh) (mise)              |
-| `actionlint` | Lint GitHub Actions workflow files               | [actionlint](https://github.com/rhysd/actionlint) (mise) |
+| Hook         | Description                                      | Requirements                                               |
+| ------------ | ------------------------------------------------ | ---------------------------------------------------------- |
+| `format`     | Remove trailing whitespace, ensure final newline | [basefmt](https://github.com/fohte/basefmt) (mise)         |
+| `prettier`   | Auto-format with Prettier                        | [Prettier](https://prettier.io/) (bun/pnpm/npm/mise)       |
+| `shellcheck` | Lint shell scripts                               | [ShellCheck](https://www.shellcheck.net/) (mise)           |
+| `shfmt`      | Format shell scripts                             | [shfmt](https://github.com/mvdan/sh) (mise)                |
+| `pinact`     | Pin GitHub Actions to commit SHAs                | [pinact](https://github.com/suzuki-shunsuke/pinact) (mise) |
+| `actionlint` | Lint GitHub Actions workflow files               | [actionlint](https://github.com/rhysd/actionlint) (mise)   |

--- a/base.yml
+++ b/base.yml
@@ -38,6 +38,11 @@ pre-commit:
       run: mise x shfmt -- shfmt --apply-ignore -w {staged_files}
       stage_fixed: true
 
+    pinact:
+      glob: '.github/workflows/*.{yml,yaml}'
+      run: mise x pinact -- pinact run {staged_files}
+      stage_fixed: true
+
     actionlint:
       glob: '.github/workflows/*.{yml,yaml}'
       run: mise x actionlint -- actionlint {staged_files}

--- a/base.yml
+++ b/base.yml
@@ -39,7 +39,7 @@ pre-commit:
       stage_fixed: true
 
     pinact:
-      glob: '.github/workflows/*.{yml,yaml}'
+      glob: '{.github/workflows/*.{yml,yaml},.github/actions/**/action.{yml,yaml}}'
       run: mise x pinact -- pinact run {staged_files}
       stage_fixed: true
 


### PR DESCRIPTION
## Why

- GitHub Actions workflows have no automatic defense against supply chain attacks such as tag tampering

## What

- Run `pinact` as a pre-commit hook to automatically pin GitHub Actions references to SHA digests

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fohte/lefthook-config/pull/365" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
