### PR TITLE
fix(base): detect packageManager field before falling back to lockfile lookup

### DIFF
--- a/base.yml
+++ b/base.yml
@@ -11,15 +11,33 @@ pre-commit:
 
     prettier:
       run: |
-        if [ -f bun.lockb ] || [ -f bun.lock ]; then
-          runner="bun x"
-        elif [ -f pnpm-lock.yaml ]; then
-          runner="pnpm exec"
-        elif [ -f package.json ]; then
-          runner="npx"
-        else
-          runner="mise x --"
+        # Detect the package manager in priority order:
+        # corepack's packageManager field wins over lockfile detection so that
+        # non-workspace monorepos (root package.json without a root lockfile) still
+        # pick pnpm/bun instead of falling back to npx and hanging on a prompt.
+        pm=""
+        if [ -f package.json ]; then
+          pm=$(grep -E '"packageManager"[[:space:]]*:' package.json \
+            | head -n 1 \
+            | sed -E 's/.*"packageManager"[[:space:]]*:[[:space:]]*"([^"@]+)@[^"]*".*/\1/')
         fi
+        case "$pm" in
+          bun) runner="bun x" ;;
+          pnpm) runner="pnpm exec" ;;
+          yarn) runner="yarn" ;;
+          npm) runner="npx" ;;
+          *)
+            if [ -f bun.lockb ] || [ -f bun.lock ]; then
+              runner="bun x"
+            elif [ -f pnpm-lock.yaml ]; then
+              runner="pnpm exec"
+            elif [ -f package.json ]; then
+              runner="npx"
+            else
+              runner="mise x --"
+            fi
+            ;;
+        esac
         $runner prettier --write --ignore-unknown --no-error-on-unmatched-pattern {staged_files}
       stage_fixed: true
 
@@ -70,13 +88,31 @@ commit-msg:
   commands:
     commitlint:
       run: |
-        if [ -f bun.lockb ] || [ -f bun.lock ]; then
-          runner="bun x"
-        elif [ -f pnpm-lock.yaml ]; then
-          runner="pnpm exec"
-        elif [ -f package.json ]; then
-          runner="npx"
-        else
-          runner="mise x --"
+        # Detect the package manager in priority order:
+        # corepack's packageManager field wins over lockfile detection so that
+        # non-workspace monorepos (root package.json without a root lockfile) still
+        # pick pnpm/bun instead of falling back to npx and hanging on a prompt.
+        pm=""
+        if [ -f package.json ]; then
+          pm=$(grep -E '"packageManager"[[:space:]]*:' package.json \
+            | head -n 1 \
+            | sed -E 's/.*"packageManager"[[:space:]]*:[[:space:]]*"([^"@]+)@[^"]*".*/\1/')
         fi
+        case "$pm" in
+          bun) runner="bun x" ;;
+          pnpm) runner="pnpm exec" ;;
+          yarn) runner="yarn" ;;
+          npm) runner="npx" ;;
+          *)
+            if [ -f bun.lockb ] || [ -f bun.lock ]; then
+              runner="bun x"
+            elif [ -f pnpm-lock.yaml ]; then
+              runner="pnpm exec"
+            elif [ -f package.json ]; then
+              runner="npx"
+            else
+              runner="mise x --"
+            fi
+            ;;
+        esac
         $runner commitlint --edit {1}


### PR DESCRIPTION
## Why

- pnpm-based projects whose root has no `pnpm-lock.yaml` (e.g. the Non-workspace monorepo layout produced by `generic-boilerplate`) fall through to `npx` in the pre-commit prettier hook and the commit-msg commitlint hook, and then hang on the `Ok to proceed? (y)` prompt so the commit never finishes
  - The previous runner detection only looked at lockfile presence and ignored corepack's `packageManager` field

## What

- Read the `packageManager` field (`pnpm@...` / `bun@...` / `yarn@...` / `npm@...`) from the root `package.json` before the lockfile check in both the prettier and commitlint hooks of `base.yml`
- Keep the existing lockfile fallback (`bun.lockb`/`bun.lock` -> `pnpm-lock.yaml` -> `package.json` -> `mise x --`) for projects that do not declare `packageManager`

Example:

```json
{
  "name": "root",
  "private": true,
  "packageManager": "pnpm@10.33.0"
}
```

A root `package.json` like the above now resolves to `pnpm exec` even when no lockfile sits next to it.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fohte/lefthook-config/pull/370" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
